### PR TITLE
Fix: support native parameter types (booleans, numbers, strings) in controls_with_params and refine parameter filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,26 @@ controls_with_params = [
     organizational_unit_ids = ["ou-2222-22222222"...]
   }
 ]
+
+controls_with_params = [
+  {
+    # パラメータつきのコントロール
+    control_names = [
+      {
+        # AWS-GR_RESTRICT_ROOT_USER
+        "5kvme4m5d2b4d7if2fs5yg2ui" = {
+          parameters = {
+            # AssumeRole（AssumeRoot）を経由して実行されたリクエストは除外され、本当にrootユーザーで直接実行された操作のみが違反検出対象になる
+            ExemptAssumeRoot = true
+          }
+        }
+      }
+    ],
+    organizational_unit_ids = [
+      "ou-xxxx"
+    ]
+  }
+]
 ```
 
 1. Open [All global identifiers](https://docs.aws.amazon.com/controltower/latest/controlreference/all-global-identifiers.html) in the AWS Control Tower documentation.

--- a/main.tf
+++ b/main.tf
@@ -81,16 +81,8 @@ locals {
         for ou_id in control_group.organizational_unit_ids : {
           control_id = keys(control)[0]
           ou_id      = ou_id
-          parameters = try(
-            # Get parameters if they exist, filter out empty lists
-            {
-              for k, v in values(control)[0].parameters :
-              k => v
-              if length(v) > 0
-            },
-            null
-          )
-          # parameters  = try(values(control)[0].parameters, null)
+          # Pass-through parameters as provided in tfvars (no filtering)
+          parameters  = try(values(control)[0].parameters, null)
           tags = try(values(control)[0].tags, null)
         }
       ]

--- a/variables.tf
+++ b/variables.tf
@@ -31,7 +31,7 @@ variable "controls_with_params" {
   type = list(
     object({
       control_names = list(map(object({
-        parameters = optional(map(list(string)))
+        parameters = optional(map(any))
       })))
       organizational_unit_ids = list(string)
     })


### PR DESCRIPTION
This PR enhances the controls_with_params handling to support native parameter types (e.g., booleans, numbers, strings) instead of forcing all parameters to be list(string).
It also fixes the filtering logic that assumed list-only values, which caused type errors or dropped valid parameters.